### PR TITLE
ci: publish npm package on GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,34 @@
 name: Publish package
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types:
+      - published
   workflow_dispatch:
+    inputs:
+      npm_tag:
+        description: npm dist-tag to publish under
+        required: false
+        default: latest
+
+concurrency:
+  group: publish-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
+      IS_PRERELEASE: ${{ github.event.release.prerelease || false }}
+      INPUT_NPM_TAG: ${{ inputs.npm_tag || '' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -25,6 +40,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate release tag matches package version
+        shell: bash
+        run: |
+          set -euo pipefail
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          EXPECTED_TAG="v${PKG_VERSION}"
+          if [ "$RELEASE_TAG" != "$EXPECTED_TAG" ]; then
+            echo "Release tag $RELEASE_TAG does not match package.json version $PKG_VERSION" >&2
+            exit 1
+          fi
+
       - name: Run typecheck
         run: npm run typecheck
 
@@ -34,7 +60,21 @@ jobs:
       - name: Build package
         run: npm run build
 
+      - name: Resolve npm dist-tag
+        id: dist_tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_NPM_TAG" ]; then
+            TAG="$INPUT_NPM_TAG"
+          elif [ "$IS_PRERELEASE" = "true" ]; then
+            TAG="next"
+          else
+            TAG="latest"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --access public --tag "${{ steps.dist_tag.outputs.tag }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Publish to npm automatically when a GitHub Release is published
+- Validate that the release tag matches `package.json` version before publishing
+- Publish prereleases to npm under the `next` dist-tag by default
+
 ## 0.1.0
 
 - Initial standalone `openclaw_bridge` adapter package for Paperclip

--- a/README.md
+++ b/README.md
@@ -67,13 +67,25 @@ npm run test
 npm run build
 ```
 
-## Publish
+## Release and publish
 
-```bash
-npm publish --access public
-```
+Publishing is automated through GitHub Actions when a **GitHub Release** is published.
 
-If npm auth is not already configured in your environment, publishing will fail until you log in or provide a token.
+### Stable release flow
+
+1. Merge code to `main`
+2. Bump `package.json` version
+3. Update `CHANGELOG.md`
+4. Create and publish a GitHub Release with tag `vX.Y.Z`
+5. The workflow validates that the tag matches `package.json`, then runs typecheck, tests, build, and `npm publish`
+
+### Prerelease flow
+
+If you publish a GitHub prerelease such as `v0.2.0-beta.1`, the workflow publishes it to npm under the `next` dist-tag by default.
+
+### Manual fallback
+
+The workflow also supports manual dispatch if a release ever needs to be re-run deliberately.
 
 ## Package contract
 


### PR DESCRIPTION
## Summary
- publish to npm when a GitHub Release is published instead of on raw tag push
- validate that the release tag matches the package version before publishing
- document stable and prerelease release flow in the README

## Validation
- npm ci --include=dev
- ./node_modules/.bin/tsc --noEmit -p tsconfig.json
- npm test
- npm run build
