### PR TITLE
fix: pass node auth token to release publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- pass NODE_AUTH_TOKEN alongside NPM_TOKEN in the Changesets release workflow
- fix automated npm publish for merged release PRs

## Why
The new Changesets flow successfully created the release PR, but publish failed on merge. This makes the workflow consistent with the original publish setup, which used NODE_AUTH_TOKEN for npm auth.
