### PR TITLE
fix: align package shape with external adapter examples

### DIFF
--- a/.changeset/lucky-dolphins-try.md
+++ b/.changeset/lucky-dolphins-try.md
@@ -1,0 +1,5 @@
+---
+"paperclip-openclaw-bridge": patch
+---
+
+Align package metadata and root exports more closely with known external adapter examples by adding manifest metadata, a default adapter export, and explicit main/types entries.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -12,8 +12,20 @@
     "url": "https://github.com/gregagi/paperclip-openclaw-bridge.git"
   },
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "paperclip": {
-    "adapterUiParser": "1.0.0"
+    "adapterUiParser": "1.0.0",
+    "manifest": "./dist/index.js",
+    "adapters": [
+      {
+        "type": "openclaw_bridge",
+        "label": "OpenClaw Bridge",
+        "serverModule": "./dist/server/index.js",
+        "uiModule": "./dist/ui/index.js",
+        "cliModule": "./dist/cli/index.js"
+      }
+    ]
   },
   "exports": {
     ".": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,22 @@
+import { createServerAdapter } from "./server/adapter.js";
+
 export const type = "openclaw_bridge";
 export const label = "OpenClaw Bridge";
 
 export const models: { id: string; label: string }[] = [];
+
+export const manifest = {
+  id: "paperclip-openclaw-bridge",
+  name: label,
+  description: "Third-party Paperclip adapter for OpenClaw Gateway",
+  adapters: [
+    {
+      type,
+      label,
+      models,
+    },
+  ],
+};
 
 export const agentConfigurationDoc = `# openclaw_bridge agent configuration
 
@@ -49,3 +64,4 @@ Compatibility note:
 `;
 
 export { createServerAdapter } from "./server/adapter.js";
+export default createServerAdapter();

--- a/test/execute.test.ts
+++ b/test/execute.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { createServer } from "node:http";
 import { WebSocketServer } from "ws";
 import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import adapterDefault, { manifest } from "../src/index.js";
 import { execute, resolveSessionKey } from "../src/server/execute.js";
 import { createServerAdapter } from "../src/server/adapter.js";
 
@@ -135,6 +136,16 @@ describe("resolveSessionKey", () => {
     expect(resolveSessionKey({ strategy: "fixed", configuredSessionKey: "agent:meridian:paperclip", agentId: "meridian", runId: "run-123", issueId: null })).toBe(
       "agent:meridian:paperclip",
     );
+  });
+});
+
+describe("package root exports", () => {
+  it("exposes manifest metadata and a default server adapter instance", () => {
+    expect(manifest).toMatchObject({
+      id: "paperclip-openclaw-bridge",
+      adapters: [{ type: "openclaw_bridge", label: "OpenClaw Bridge" }],
+    });
+    expect(adapterDefault).toMatchObject({ type: "openclaw_bridge" });
   });
 });
 


### PR DESCRIPTION
## Summary
- add manifest metadata and explicit adapter entries under package.json paperclip metadata
- add root default export for the server adapter instance
- add explicit main/types fields and regression coverage for the root package shape

## Why
This does not replace the config-schema fix, but it makes the package look more like the strongest public external adapter examples (especially the Ollama adapter) and removes one more possible loader/metadata mismatch.

## Validation
- npm run typecheck
- npm test
- npm run build
