### PR TITLE
fix: expose stable OpenClaw device config

### DIFF
--- a/.changeset/lucky-dolphins-try.md
+++ b/.changeset/lucky-dolphins-try.md
@@ -1,0 +1,5 @@
+---
+"paperclip-openclaw-bridge": patch
+---
+
+Align package metadata and root exports more closely with known external adapter examples by adding manifest metadata, a default adapter export, and explicit main/types entries.

--- a/.changeset/stable-devices-happen.md
+++ b/.changeset/stable-devices-happen.md
@@ -1,0 +1,5 @@
+---
+"paperclip-openclaw-bridge": patch
+---
+
+Expose stable device-auth configuration in the adapter schema, including `devicePrivateKeyPem`, and default requested scopes to include `operator.pairing` for auto-pairing flows.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -51,13 +51,22 @@ Use adapter type `openclaw_bridge` and config like:
 {
   "url": "ws://127.0.0.1:18789",
   "role": "operator",
-  "scopes": ["operator.admin"],
+  "scopes": ["operator.admin", "operator.pairing"],
   "authToken": "<gateway-token>",
+  "devicePrivateKeyPem": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+  "deviceFamily": "paperclip-openclaw-bridge",
   "timeoutSec": 120,
   "waitTimeoutMs": 120000,
   "disableDeviceAuth": false,
   "sessionKeyStrategy": "issue"
 }
+```
+
+For device-auth deployments, generate a dedicated Ed25519 private key and save the full private PEM in `devicePrivateKeyPem`. Without a persisted key the adapter generates an ephemeral device identity each run, so every heartbeat can require a fresh manual approval.
+
+```bash
+openssl genpkey -algorithm Ed25519 -out ari-openclaw-device-key.pem
+cat ari-openclaw-device-key.pem
 ```
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -12,8 +12,20 @@
     "url": "https://github.com/gregagi/paperclip-openclaw-bridge.git"
   },
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "paperclip": {
-    "adapterUiParser": "1.0.0"
+    "adapterUiParser": "1.0.0",
+    "manifest": "./dist/index.js",
+    "adapters": [
+      {
+        "type": "openclaw_bridge",
+        "label": "OpenClaw Bridge",
+        "serverModule": "./dist/server/index.js",
+        "uiModule": "./dist/ui/index.js",
+        "cliModule": "./dist/cli/index.js"
+      }
+    ]
   },
   "exports": {
     ".": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,9 @@ Gateway connect identity fields:
 - clientMode (string, optional): gateway client mode (default backend)
 - clientVersion (string, optional): client version string
 - role (string, optional): gateway role (default operator)
-- scopes (string[] | comma string, optional): gateway scopes (default ["operator.admin"])
+- scopes (string[] | comma string, optional): gateway scopes (default ["operator.admin", "operator.pairing"]); the gateway token must also be allowed to use requested scopes
+- devicePrivateKeyPem (string, recommended): dedicated Ed25519 private key PEM used for stable device identity across heartbeats
+- deviceFamily (string, optional): label sent with device-auth pairing requests (default paperclip-openclaw-bridge)
 - disableDeviceAuth (boolean, optional): disable signed device payload in connect params (default false)
 
 Request behavior fields:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,22 @@
+import { createServerAdapter } from "./server/adapter.js";
+
 export const type = "openclaw_bridge";
 export const label = "OpenClaw Bridge";
 
 export const models: { id: string; label: string }[] = [];
+
+export const manifest = {
+  id: "paperclip-openclaw-bridge",
+  name: label,
+  description: "Third-party Paperclip adapter for OpenClaw Gateway",
+  adapters: [
+    {
+      type,
+      label,
+      models,
+    },
+  ],
+};
 
 export const agentConfigurationDoc = `# openclaw_bridge agent configuration
 
@@ -49,3 +64,4 @@ Compatibility note:
 `;
 
 export { createServerAdapter } from "./server/adapter.js";
+export default createServerAdapter();

--- a/src/server/adapter.ts
+++ b/src/server/adapter.ts
@@ -53,8 +53,21 @@ const configSchema: AdapterConfigSchema = {
       key: "scopes",
       label: "Gateway scopes",
       type: "text",
-      default: "operator.admin",
-      hint: "Comma-separated scopes. Example: operator.admin,operator.read",
+      default: "operator.admin,operator.pairing",
+      hint: "Comma-separated scopes. Include operator.pairing if you want automatic device-pair approval; the gateway token must also be allowed to use that scope.",
+    },
+    {
+      key: "devicePrivateKeyPem",
+      label: "Device private key PEM",
+      type: "textarea",
+      hint: "Paste a dedicated Ed25519 PRIVATE KEY PEM to keep the bridge device id stable across heartbeats. Generate with: openssl genpkey -algorithm Ed25519 -out ari-openclaw-device-key.pem",
+    },
+    {
+      key: "deviceFamily",
+      label: "Device family",
+      type: "text",
+      default: "paperclip-openclaw-bridge",
+      hint: "Optional label sent with device-auth pairing requests.",
     },
     {
       key: "disableDeviceAuth",

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -84,7 +84,7 @@ type GatewayClientRequestOptions = {
 };
 
 const PROTOCOL_VERSION = 3;
-const DEFAULT_SCOPES = ["operator.admin"];
+const DEFAULT_SCOPES = ["operator.admin", "operator.pairing"];
 const DEFAULT_CLIENT_ID = "gateway-client";
 const DEFAULT_CLIENT_MODE = "backend";
 const DEFAULT_CLIENT_VERSION = "paperclip";
@@ -1071,7 +1071,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const clientVersion = nonEmpty(ctx.config.clientVersion) ?? DEFAULT_CLIENT_VERSION;
   const role = nonEmpty(ctx.config.role) ?? DEFAULT_ROLE;
   const scopes = normalizeScopes(ctx.config.scopes);
-  const deviceFamily = nonEmpty(ctx.config.deviceFamily);
+  const deviceFamily = nonEmpty(ctx.config.deviceFamily) ?? "paperclip-openclaw-bridge";
   const disableDeviceAuth = parseBoolean(ctx.config.disableDeviceAuth, false);
 
   const wakePayload = buildWakePayload(ctx);

--- a/test/execute.test.ts
+++ b/test/execute.test.ts
@@ -157,6 +157,8 @@ describe("createServerAdapter", () => {
     expect(schema?.fields.some((field) => field.key === "url" && field.required === true)).toBe(true);
     expect(schema?.fields.some((field) => field.key === "authToken")).toBe(true);
     expect(schema?.fields.some((field) => field.key === "sessionKeyStrategy")).toBe(true);
+    expect(schema?.fields.some((field) => field.key === "devicePrivateKeyPem" && field.type === "textarea")).toBe(true);
+    expect(schema?.fields.some((field) => field.key === "scopes" && String(field.default).includes("operator.pairing"))).toBe(true);
   });
 });
 

--- a/test/execute.test.ts
+++ b/test/execute.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { createServer } from "node:http";
 import { WebSocketServer } from "ws";
 import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import adapterDefault, { manifest } from "../src/index.js";
 import { execute, resolveSessionKey } from "../src/server/execute.js";
 import { createServerAdapter } from "../src/server/adapter.js";
 
@@ -135,6 +136,16 @@ describe("resolveSessionKey", () => {
     expect(resolveSessionKey({ strategy: "fixed", configuredSessionKey: "agent:meridian:paperclip", agentId: "meridian", runId: "run-123", issueId: null })).toBe(
       "agent:meridian:paperclip",
     );
+  });
+});
+
+describe("package root exports", () => {
+  it("exposes manifest metadata and a default server adapter instance", () => {
+    expect(manifest).toMatchObject({
+      id: "paperclip-openclaw-bridge",
+      adapters: [{ type: "openclaw_bridge", label: "OpenClaw Bridge" }],
+    });
+    expect(adapterDefault).toMatchObject({ type: "openclaw_bridge" });
   });
 });
 


### PR DESCRIPTION
## Summary
- expose devicePrivateKeyPem in the OpenClaw Bridge adapter config schema as a textarea
- default requested gateway scopes to include operator.pairing
- add deviceFamily config/default so pairing requests are labeled consistently
- document dedicated Ed25519 key generation and add schema coverage

## Verification
- npm test
- npm run typecheck
- npm run build